### PR TITLE
Changed the .gitignore to filter all node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # dependencies
-node_modules
+**/node_modules
 .webpack
 
 # testing


### PR DESCRIPTION
Including folders in the subdirectories of the repo.

With this minor change we can avoid tracking all the node modules folders created when testing or debugging the create-frigg-app.