### PR TITLE
Update gitignore

### DIFF
--- a/packages/cfa-template/template/gitignore
+++ b/packages/cfa-template/template/gitignore
@@ -2,7 +2,7 @@
 
 # dependencies
 
-node_modules
+**node_modules**
 /.pnp
 .pnp.js
 
@@ -29,5 +29,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log\*
 
-.webpack
+**.webpack**
 coverage


### PR DESCRIPTION
This is needed to ignore `.webpack` in nested directories like `backend/webpack`

Currently, those files are not ignored.

<img width="838" alt="Screen Shot 2023-02-15 at 10 13 35 AM" src="https://user-images.githubusercontent.com/3011407/219051264-49664510-c883-45d7-8956-3ee69b101b90.png">

Fixed with `**` syntax

<img width="812" alt="Screen Shot 2023-02-15 at 10 14 58 AM" src="https://user-images.githubusercontent.com/3011407/219051631-46ceed03-4778-4710-85b9-c4e084daeeb5.png">
